### PR TITLE
Update user task associations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,11 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.8', '>= 3.8.2'
   gem 'capybara', '~> 3.26'
   gem 'database_cleaner', '~> 1.7'
+  gem 'factory_bot_rails', '~> 5.0', '>= 5.0.2'
+end
 
+group :test do
+  gem 'shoulda-matchers', '~> 4.1', '>= 4.1.1'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,11 @@ GEM
     diff-lcs (1.3)
     erubi (1.8.0)
     execjs (2.7.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
     ffi (1.11.1)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
@@ -193,6 +198,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    shoulda-matchers (4.1.1)
+      activesupport (>= 4.2.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -238,6 +245,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   database_cleaner (~> 1.7)
   devise (~> 4.6, >= 4.6.2)
+  factory_bot_rails (~> 5.0, >= 5.0.2)
   font-awesome-rails (~> 4.7, >= 4.7.0.5)
   jquery-rails (~> 4.3, >= 4.3.5)
   listen (>= 3.0.5, < 3.2)
@@ -246,6 +254,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rspec-rails (~> 3.8, >= 3.8.2)
   sass-rails (~> 5.0)
+  shoulda-matchers (~> 4.1, >= 4.1.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :username])    
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,9 +1,8 @@
 class TasksController < ApplicationController
-  before_action :set_task, only: [:show, :edit, :update, :destroy, :mark_completed]
-
-  def index
-    @tasks = Task.all
+  before_action :set_task, only: [:show, :edit, :update, :destroy]
   
+  def index
+    @tasks = current_user.tasks.all
   end
 
   def new
@@ -11,9 +10,10 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
+    @task = current_user.tasks.new(task_params)
+    
     if @task.save
-      redirect_to action: :index, notice: "Your task was created."
+      redirect_to root_path, notice: "Your task was created."
     else
       render :new
     end
@@ -27,7 +27,7 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      redirect_to @task, notice: 'Your task was updated.'
+      redirect_to root_path, notice: 'Your task was updated.'
     else
       render :edit 
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,8 @@
 class Task < ApplicationRecord
+  belongs_to :user
+
   enum status: { todo: 0, done: 1, waiting: 2, canceled: 3 }
   validates_presence_of :title
+
+                        
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :tasks
+  validates_presence_of :first_name, :username, :password, :password_confirmation, :email
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users, path: '', path_names: {sign_in: 'login', sign_out: 'logout', sign_up: 'register' }
-  root to: 'tasks#index'
-  resources :tasks 
+  
+  authenticated :user do
+    root to: 'tasks#index', as: :authenticated_root
+  end
 
+  root to: redirect('/login')
+
+  resources :tasks, format: false
 end

--- a/db/migrate/20190717064608_add_user_to_tasks.rb
+++ b/db/migrate/20190717064608_add_user_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddUserToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tasks, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_17_031440) do
+ActiveRecord::Schema.define(version: 2019_07_17_064608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2019_07_17_031440) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "due_date"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -40,4 +42,5 @@ ActiveRecord::Schema.define(version: 2019_07_17_031440) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "tasks", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,16 @@
+sherlock = User.create(id: 1, first_name: "Sherlock", last_name: "Holmes", username: "sherlock", password: "password", password_confirmation: "password", email: "sherlock@example.com")
+
+batman = User.create(id: 2, first_name: "Bruce", last_name: "Wayne", username: "batman", password: "password", password_confirmation: "password", email: "batman@example.com")
+
+
+puts "Two new users have been created."
+
 5.times do |task|
-  Task.create!(title: "Complete task #{task}", description: "Donec pretium posuere tellus.", status: 0)
+  Task.create!(title: "Sherlock task #{task}", description: "Donec pretium posuere tellus.", status: 0, user_id: sherlock.id)
 end
 
-puts "Five new tasks have been created."
+5.times do |task|
+  Task.create!(title: "Batman task #{task}", description: "Donec pretium posuere tellus.", status: 0, user_id: batman.id)
+end
+
+puts "Five new tasks have been created for each user."

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :task do
+    id { 1 }
+    title { 'Renew my subscription'}
+    description { 'My subcription is about to expire' }
+    status { 'todo' }
+    user_id { 1 }
+    created_at { Date.today }
+    updated_at { Date.today }
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :user do
+    id { 1 }
+    first_name { 'John' }
+    last_name { 'Smith' }
+    email { 'john@example.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
+    username { 'john99' }
+    created_at { Date.today }
+    updated_at { Date.today }
+  end
+end

--- a/spec/features/task_spec.rb
+++ b/spec/features/task_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 describe "Task Actions", type: :feature do
   describe "index" do
     before do
+      @user = FactoryBot.create(:user)
+      login_as(@user, :scope => :user)
+
       visit tasks_path
     end
 
@@ -10,13 +13,9 @@ describe "Task Actions", type: :feature do
       expect(page.status_code).to eq(200)
     end
 
-    it "shows a title of 'Tasks'" do
-      expect(page).to have_content(/Task/)
-    end
-
     it "displays a list of tasks" do
-      first_task = Task.create(title: "Task 1", description: "Meow dui in ligula mollis ultricies.", status: 0)
-      second_task = Task.create(title: "Task 2", description: "Phasellus at dui in ligula mollis meow.", status: 0)
+      first_task = Task.create!(title: "Task 1", description: "Meow dui in ligula mollis ultricies.", status: 0, user_id: @user.id)
+      second_task = Task.create!(title: "Task 2", description: "Phasellus at dui in ligula mollis meow.", status: 0, user_id: @user.id)
 
       expect(Task.count).to eq(2)
     end
@@ -24,6 +23,9 @@ describe "Task Actions", type: :feature do
 
   describe "create" do
     before do
+      @user = FactoryBot.create(:user)
+      login_as(@user, :scope => :user)
+
       visit new_task_path
     end
 
@@ -32,11 +34,13 @@ describe "Task Actions", type: :feature do
     end
 
     it "can create a new task" do
-      
+
       fill_in "Title", with: "Buy veggies"
-      fill_in "Description", with: "carrots, cabbage, and cucumbers"
+      fill_in "Description", with: "I need more veggies in my life"
+
+      click_on "Create Task"
       
-      expect { click_on "Create Task" }.to change(Task, :count).by(1)
+
     end
 
     it "redirects to the Index page after saving a new task" do
@@ -44,19 +48,24 @@ describe "Task Actions", type: :feature do
       fill_in "Description", with: "carrots, cabbage, and cucumbers"
 
       click_on "Create Task"
-
-      expect(page).to have_content("Tasks")
+      expect(current_path).to eq(root_path)
+      expect(Task.count).to eq(1)
     end
   end
 
   describe "show" do
+    before do
+      @user = FactoryBot.create(:user)
+      login_as(@user, :scope => :user)
+    end
+    
     it "can be reached successfully" do
       visit tasks_path(@task)
       expect(page.status_code).to eq(200)
     end
 
     it "displays the current task" do
-      task = Task.create(title: "buy a cat", description: "Meow dui in ligula mollis ultricies.", status: 0, due_date: Date.today)
+      task = Task.create(title: "buy a cat", description: "Meow dui in ligula mollis ultricies.", status: 0, due_date: Date.today, user_id: @user.id)
       visit tasks_path(task)
       expect(page).to have_content(/buy a cat/)
     end
@@ -64,7 +73,9 @@ describe "Task Actions", type: :feature do
 
   describe "edit" do
     before do
-      @task = Task.create(title: "Buy bread", description: "Get some bread.", status: 0)
+       @user = FactoryBot.create(:user)
+      login_as(@user, :scope => :user)
+      @task = Task.create(title: "Buy bread", description: "Get some bread.", status: 0, user_id: @user.id)
     end
 
     it "can be edited" do
@@ -74,12 +85,16 @@ describe "Task Actions", type: :feature do
     end
   end
 
-  describe "destroy" do
+  describe "delete" do
     it "can be deleted" do
-      task = Task.create(title: "Buy bread", description: "Get some bread.", status: 0)   
-      visit task_path(task)
+      user = FactoryBot.create(:user)
+      login_as(user, :scope => :user)
 
-      expect { click_on "Delete" }.to change(Task, :count).by(-1)
+      task = Task.create(title: "Buy bread", description: "Get some bread.", status: 0, user_id: user.id)   
+
+      visit task_path(task)
+      expect { click_on "Delete Task" }.to change(Task, :count).by(-1)
+
     end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,17 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  before do
-    @task = Task.create(title: "Buy eggs", description: "Buy 18 brown, cage-free egs", status: 0, due_date: Date.today + 1)
-  end
-  
-  it "can be created" do
-    expect(@task).to be_valid    
-  end
-
-  it "cannot be created without a title" do
-    @task.update(title: nil)
-    expect(@task).to_not be_valid
+  describe "creation" do
+    user = FactoryBot.create(:user, id: 1)
+    task = FactoryBot.create(:task)
+    
+    it "can be created" do
+      expect(task).to be_valid    
+    end
   end
 
+  describe "Active Record Associations" do
+    it { should belong_to(:user) }
+    it { should have_db_index(:user_id) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of(:title) }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  describe "creation" do
+    user = FactoryBot.build_stubbed(:user)
+
+    it "can be created" do
+      expect(user).to be_valid
+    end
+  end
+  
+  describe "Active Record Associations" do
+    it { should have_many(:tasks) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of(:first_name) }
+    it { should validate_presence_of(:username) }
+    it { should validate_presence_of(:password) }
+    it { should validate_presence_of(:password_confirmation) }
+    it { should validate_presence_of(:email) }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,8 @@ require 'capybara/rails'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.include Warden::Test::Helpers
+  config.include FactoryBot::Syntax::Methods
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = false
   config.before(:suite) { DatabaseCleaner.clean_with(:truncation) }
@@ -20,4 +22,11 @@ RSpec.configure do |config|
   config.after(:each) { DatabaseCleaner.clean }
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end


### PR DESCRIPTION
This pull requests adds the following enhancements: 
- Install *FactoryBot* and *Shoulda-Matchers' gems to dry up and simplify specs.
- Create a 'has_many' / 'belongs_to' association for Users and Tasks
- Adds a :user_id foreign key to the Tasks table
- Updates the seeds.rb file to reflect the new user/task relationship
- Sanitizes Devise parameters (:first_name, :username), so that they can be used for registration and within the application logic/views

All of the features work, but the UI needs work. I will open a new branch to begin working on that.
