### PR TITLE
Fix navbar and task spec issues

### DIFF
--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -2,9 +2,10 @@
   <%= link_to "Kick it into Gear!", root_path, class: "navbar-brand" %>
 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
-  </button>
+</button>
+<% if user_signed_in? %>
         <%= link_to 'Add Task', new_task_path,  {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal-window', class: 'btn btn-primary btn-sm'}  %>
-
+<% end %>
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <li class="nav-item active">

--- a/spec/features/task_spec.rb
+++ b/spec/features/task_spec.rb
@@ -59,7 +59,8 @@ describe "Task Actions", type: :feature do
     end
 
     it "displays the current task" do
-      task = Task.create(title: "buy a cat", description: "Meow dui in ligula mollis ultricies.", status: 0, due_date: Date.today, user_id: @user.id)
+           task = Task.create(title: "buy a cat", description: "Meow dui in ligula mollis ultricies.", status: 0, due_date: Date.today, user_id: @user.id)
+           
       visit tasks_path(task)
       expect(page).to have_content(/buy a cat/)
     end
@@ -69,7 +70,8 @@ describe "Task Actions", type: :feature do
     before do
       @user = FactoryBot.create(:user)
       login_as(@user, :scope => :user)
-      @task = Task.create(title: "Buy bread", description: "Get some bread.", status: 0, user_id: @user.id)
+      #      @task = Task.create(title: "Buy bread", description: "Get some bread.", status: 0, user_id: @user.id)
+      @task = FactoryBot.create(:task)
     end
 
     it "can be edited" do
@@ -82,17 +84,16 @@ describe "Task Actions", type: :feature do
   end
 
   describe "delete", js: true do
-
     it "can be deleted" do
       user = FactoryBot.create(:user)
       login_as(user, :scope => :user)
 
-      
-      task = Task.create(title: "Buy bread", description: "Get some bread.", status: 0, user_id: user.id)   
-      visit root_path
-      click_on "Delete"
+      task = FactoryBot.create(:task)
 
-      expect(Task.count).to eq(0)
+      visit root_path
+      find(".btn-danger", match: :first).click
+      wait_for_ajax
+      expect(user.tasks.count).to eq(0)
     end
   end
 end

--- a/spec/helpers/wait_for_ajax.rb
+++ b/spec/helpers/wait_for_ajax.rb
@@ -1,0 +1,16 @@
+# spec/support/wait_for_ajax.rb
+module WaitForAjax
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    sleep 1
+  end
+end
+
+RSpec.configure do |config|
+  config.include WaitForAjax, type: :feature
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rails'
 require 'capybara/apparition'
+require 'helpers/wait_for_ajax'
 Capybara.javascript_driver = :apparition
 
 ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
This PR fixes two annoying issues:

1. I forgot to hide the 'Add Task' button from the nav bar when users were not logged in. It was not functional, but visible to non-authenticated users. Now, it only shows up when a user is logged in. 

2. I've been dealing an annoying issue with my 'delete' action spec in my 'spec/features/task_spec.rb' suite. When the tests were Rack-based, they were bulletproof. But when I refactored to make the buttons use Ajax, I had a race-condition where the Delete would sometimes fail, and sometimes pass. 

I adopted a strategy based on [this solution from Thoughtbot](https://thoughtbot.com/blog/automatically-wait-for-ajax-with-capybara).  In addition to using Byebug to check the Task.count at various stages of the method, I also ran loops in BASH to ensure that the specs passed more than once (e.g., `for i in {1..10}; do rspec; done;` Without the 'wait_for_ajax' helper method, it would randomly pass/fail. But with it, the spec passed every time.