### PR TITLE
Temp fix for 'Add Task' modal not working for new users w/o tasks

### DIFF
--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <%= link_to "Kick it into Gear!", root_path, class: "navbar-brand" %>
 
-  <% if user_signed_in? %>
+  <% if user_signed_in? && current_user.tasks.exists? %>
         <%= link_to 'Add Task', new_task_path,  {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal-window', class: 'btn btn-primary btn-sm'}  %>
   <% end %>
   

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -61,8 +61,14 @@
     </table>
 
   <% else %>
-    <h2 class="text-center"> You don't have any tasks yet. Let's create some!</h2>
+    <h2 class="text-center"> You don't have any tasks yet. Let's create one!</h2>
+    <div class="container">
+      <div class="row">
+        <div class="col text-center">
+          <%= link_to "Add your first task!", new_task_path, class: "btn btn-primary btn-lg text-center" %>
+        </div>
+      </div>
+    </div>
   <% end %>
-
 </div>
 


### PR DESCRIPTION
This PR fixes an issue where new users without any tasks cannot access the modal form to add tasks. This is only a a temporary fix, because:

1. I don't like using the conditional logic in the view template.
2. The logic itself is hacky. This used to work, and I have an idea of how to refactor this, but it's way to late tonight.

I'll open up a new branch and refactor tomorrow. I should also check my specs, and this is an edge case that I did not anticipate. 